### PR TITLE
version 0.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.json
 *backup*
 *.sh
+*.txt
 todo
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ todo
 
 
 # Byte-compiled / optimized / DLL files
-__pycache__/
+**__pycache__/
 *.py[cod]
 *$py.class
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ spotify auth login
 
 Start Spotify playback on any device and run the `spotify` command.
 ```
-> spotify
+$ spotify
 Usage: spotify [<options>] <command>
 
 Options:
@@ -34,6 +34,9 @@ Commands:
   pause     Pause playback.
   play      Resume playback.
   previous  Play the previous song in the queue.
+  repeat    Turn repeat on (all/track) or off.
+  save      Save the current track, album, artist, or playlist.
+  shuffle   Turn shuffle on or off.
   status    Describe the current playback session.
   volume    Control the active device's volume level.
 ```
@@ -42,11 +45,11 @@ Commands:
 
 Describe and control current playback.
 ```
-> spotify play
+$ spotify play
 Playing: Nights
          Frank Ocean - Blonde
 
-> spotify status -vv
+$ spotify status -vv
 Song    Nights (03:31 / 05:07)
 Artist  Frank Ocean
 Album   Blonde
@@ -55,21 +58,21 @@ Status  Playing (on repeat, 60% volume)
 Device  Lorenzo (Smartphone)
 URL:    https://open.spotify.com/track/7eqoqGkKwgOaWNNHx90uEZ
 
-> spotify vol --up 20
+$ spotify vol --up 20
 Volume set to 80%
 
-> spotify vol --to 100
+$ spotify vol --to 100
 Volume set to 100%
 ```
 
 You can also manage multiple devices.
 ```
-> spotify devices -v
+$ spotify devices -v
   LENOVO - Computer
 * Lorenzo - Smartphone
   Web Player (Chrome) - Computer
 
-> spotify devices --switch comp
+$ spotify devices --switch comp
 2 devices matched "comp".
 ? Please select the device to activate.
  > LENOVO - Computer
@@ -97,7 +100,7 @@ spotify p
 
 Some commands support the `--raw` flag to output the Spotify API JSON response (shell script-friendly).
 ```bash
-> spotify status --raw | jq --jsonargs .context
+$ spotify status --raw | jq --jsonargs .context
 {
   "external_urls": {
     "spotify": "https://open.spotify.com/album/3mH6qwIy9crq0I9YQbOuDf"

--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ Volume set to 100%
 
 You can also manage multiple devices.
 ```
-❯ spotify devices -v
+> spotify devices -v
   LENOVO - Computer
 * Lorenzo - Smartphone
   Web Player (Chrome) - Computer
 
-❯ spotify devices --switch comp
+> spotify devices --switch comp
 2 devices matched "comp".
 ? Please select the device to activate.
  > LENOVO - Computer
@@ -95,12 +95,24 @@ spotify prev
 spotify p
 ```
 
+Some commands support the `--raw` flag to output the Spotify API JSON response (shell script-friendly).
+```bash
+> spotify status --raw | jq --jsonargs .context
+{
+  "external_urls": {
+    "spotify": "https://open.spotify.com/album/3mH6qwIy9crq0I9YQbOuDf"
+  },
+  "href": "https://api.spotify.com/v1/albums/3mH6qwIy9crq0I9YQbOuDf",
+  "type": "album",
+  "uri": "spotify:album:3mH6qwIy9crq0I9YQbOuDf"
+}
+```
+
 ## Notes
 - Playback and device-related commands require at least one active Spotify session on any device.
   - You can just start and stop playback to "activate" your device.
   - Your device will remain "active" even when paused.
-- Some operations may not be supported on certain devices (i.e. volume control for mobile).
-- Behavior may differ for users not subscribed to Spotify Premium.
+- Some operations may not be supported on certain devices (i.e. volume control for mobile) and for users not subscribed to Spotify Premium.
 - In development: search, browse, more playback options, custom auth scopes.
 
 ## [License](LICENSE)

--- a/cli/commands/auth.py
+++ b/cli/commands/auth.py
@@ -1,30 +1,40 @@
 import os
 import json
 import time
-from uuid import uuid1
 
 import click
 
 from cli.utils import Spotify
-from cli.utils.constants import AUTH_URL, CREDS_PATH 
+from cli.utils.constants import *
+from cli.utils.functions import build_auth_url
 
 
 @click.command()
 def login():
     """Authorize spotify-cli to access the Spotify API."""
-    url = AUTH_URL + '&state=' + str(uuid1())
-    try:
-        import webbrowser
-        webbrowser.open(url)
-    except:
-        pass
-    
-    print('Go to the following link in your browser:\n\n\t{}\n'.format(url))
+    # select scopes
+    import webbrowser
+    from PyInquirer import prompt
+    choices = filter(lambda x: x['value'] != 'default', AUTH_SCOPES_MAPPING)
+    click.echo('By default, spotify-cli will enable reading & modifying the playback state.\n')
+    questions = [{
+        'type': 'checkbox',
+        'name': 'scopes',
+        'message': 'Please select which additional features you want to authorize.',
+        'choices': choices,
+    }]
+    choice = prompt(questions)
+    additional_scopes = choice.get('scopes')
+    url = build_auth_url(additional_scopes)
 
+    # handle auth and save credentials
+    webbrowser.open(url)
+    print('\nGo to the following link in your browser:\n\n\t{}\n'.format(url))
     auth_code = input('Enter verification code: ')
     print('\nObtaining access token...')
     Spotify.refresh(auth_code)
     print('Credentials saved to {}'.format(CREDS_PATH))
+
     return
 
 

--- a/cli/commands/auth.py
+++ b/cli/commands/auth.py
@@ -15,26 +15,46 @@ def login():
     # select scopes
     import webbrowser
     from PyInquirer import prompt
-    choices = filter(lambda x: x['value'] != 'default', AUTH_SCOPES_MAPPING)
+    enabled_scopes = Spotify.get_config().get('auth_scopes', [])
+    choices = list(filter(lambda x: x['value'] != 'default', AUTH_SCOPES_MAPPING))
+    for c in choices:
+        if c['value'] in enabled_scopes:
+            c['name'] = '(enabled) ' + c['name']
+
     click.echo('By default, spotify-cli will enable reading & modifying the playback state.\n')
-    questions = [{
+    choice = prompt([{
         'type': 'checkbox',
         'name': 'scopes',
         'message': 'Please select which additional features you want to authorize.',
         'choices': choices,
-    }]
-    choice = prompt(questions)
-    additional_scopes = choice.get('scopes')
-    url = build_auth_url(additional_scopes)
+    }])
+    if not choice:
+        return
+
+    # confirm
+    additional_scopes = choice.get('scopes', [])
+    click.echo(
+        '\n{} features selected. This will overwite your existing credentials.'
+        .format(len(additional_scopes))
+    )
+    confirmation = prompt([{
+        'type': 'confirm',
+        'name': 'confirm',
+        'message': 'Proceed with these settings?',
+    }])
+    if not confirmation.get('confirm', False):
+        click.echo('Cancelled by user')
+        return
 
     # handle auth and save credentials
+    url = build_auth_url(additional_scopes)
     webbrowser.open(url)
-    print('\nGo to the following link in your browser:\n\n\t{}\n'.format(url))
+    click.echo('\nGo to the following link in your browser:\n\n\t{}\n'.format(url))
     auth_code = input('Enter verification code: ')
-    print('\nObtaining access token...')
+    click.echo('\nObtaining access token...')
     Spotify.refresh(auth_code)
-    print('Credentials saved to {}'.format(CREDS_PATH))
-
+    Spotify.update_config({'auth_scopes': additional_scopes})
+    click.echo('Credentials saved to {}'.format(CREDS_PATH))
     return
 
 

--- a/cli/commands/devices.py
+++ b/cli/commands/devices.py
@@ -26,7 +26,8 @@ def devices(verbose=False, switch_to='', raw=False):
     res = Spotify.request('me/player/devices', method='GET')
     if raw:
         if verbose:
-            click.echo(res)
+            import json
+            click.echo(json.dumps(res))
 
         return res
 

--- a/cli/commands/pause.py
+++ b/cli/commands/pause.py
@@ -1,7 +1,6 @@
 import click
 
 from cli.utils import Spotify
-from cli.utils.exceptions import SpotifyAPIError
 
 
 @click.command(options_metavar='[<options>]')

--- a/cli/commands/pause.py
+++ b/cli/commands/pause.py
@@ -19,7 +19,7 @@ def pause(verbose=0, quiet=False):
 
     if not quiet:
         from cli.commands.status import status
-        status.callback(verbose=verbose, override={'is_playing': False})
+        status.callback(verbose=verbose, _override={'is_playing': False})
 
 
     return

--- a/cli/commands/pause.py
+++ b/cli/commands/pause.py
@@ -15,13 +15,7 @@ from cli.utils.exceptions import SpotifyAPIError
 )
 def pause(verbose=0, quiet=False):
     """Pause playback."""
-    try:
-        Spotify.request('me/player/pause', method='PUT')
-    except SpotifyAPIError as e:
-        if e.status == 403:
-            pass
-        else:
-            raise e
+    Spotify.request('me/player/pause', method='PUT', ignore_errs=[403])
 
     if not quiet:
         from cli.commands.status import status

--- a/cli/commands/play.py
+++ b/cli/commands/play.py
@@ -44,6 +44,6 @@ def play(verbose=0, quiet=False, shuffle=None, repeat=None):
 
     if not quiet:
         from cli.commands.status import status
-        status.callback(verbose=verbose, override={'is_playing': True})
+        status.callback(verbose=verbose, _override={'is_playing': True})
 
     return

--- a/cli/commands/play.py
+++ b/cli/commands/play.py
@@ -15,13 +15,7 @@ from cli.utils.exceptions import SpotifyAPIError
 )
 def play(verbose=0, quiet=False):
     """Resume playback."""
-    try:
-        Spotify.request('me/player/play', method='PUT')
-    except SpotifyAPIError as e:
-        if e.status == 403:
-            pass
-        else:
-            raise e
+    Spotify.request('me/player/play', method='PUT', ignore_errs=[403])
 
     if not quiet:
         from cli.commands.status import status

--- a/cli/commands/play.py
+++ b/cli/commands/play.py
@@ -1,7 +1,6 @@
 import click
 
 from cli.utils import Spotify
-from cli.utils.exceptions import SpotifyAPIError
 
 
 @click.command(options_metavar='[<options>]')
@@ -13,13 +12,38 @@ from cli.utils.exceptions import SpotifyAPIError
     '-q', '--quiet', is_flag=True,
     help='Suppress output.'
 )
-def play(verbose=0, quiet=False):
+@click.option(
+    '-s', '--shuffle',
+    type=click.Choice(['on', 'off'], case_sensitive=False),
+    help='Turn shuffle on or off.'
+)
+@click.option(
+    '-r', '--repeat',
+    type=click.Choice(['all', 'track', 'off'], case_sensitive=False),
+    help='Turn repeat on (all/track) or off.'
+)
+def play(verbose=0, quiet=False, shuffle=None, repeat=None):
     """Resume playback."""
+    requests = []
+    if shuffle:
+        from cli.commands.shuffle import shuffle as shuffle_cmd
+        requests.append(
+            shuffle_cmd.callback(shuffle, _create_request=True)
+        )
+        verbose = max(verbose, 1)
+
+    if repeat:
+        from cli.commands.repeat import repeat as repeat_cmd
+        requests.append(
+            repeat_cmd.callback(repeat, _create_request=True)
+        )
+        verbose = max(verbose, 1)
+
+    Spotify.multirequest(requests)
     Spotify.request('me/player/play', method='PUT', ignore_errs=[403])
 
     if not quiet:
         from cli.commands.status import status
         status.callback(verbose=verbose, override={'is_playing': True})
-
 
     return

--- a/cli/commands/repeat.py
+++ b/cli/commands/repeat.py
@@ -1,0 +1,44 @@
+import click
+
+from cli.utils import Spotify
+
+
+@click.command(options_metavar='[<options>]')
+@click.option(
+    '-v', '--verbose', count=True,
+    help='Output more info (repeatable flag).'
+)
+@click.option(
+    '-q', '--quiet', is_flag=True,
+    help='Suppress output.'
+)
+@click.argument(
+    'mode', type=click.Choice(['all', 'track', 'off'], case_sensitive=False)
+)
+def repeat(mode, verbose=0, quiet=False, wait=True):
+    """Turn repeat on (all/track) or off."""
+    state_map = {
+        'all': 'context',
+        'track': 'track',
+        'off': 'off'
+    }
+    requests = [{
+        'endpoint': 'me/player/repeat?state={}'.format(state_map[mode]),
+        'method': 'PUT'
+    }]
+    Spotify.multirequest(requests, wait=wait)
+    if quiet:
+        return
+
+    if verbose == 0:
+        if mode == 'off':
+            click.echo('Repeat turned off.')
+        elif mode == 'track':
+            click.echo('Repeat set to current track.')
+        elif mode == 'all':
+            click.echo('Repeat set to all tracks.')
+    else:
+        from cli.commands.status import status
+        status.callback(verbose=verbose, override={'is_repeat': mode in ['all', 'track']})
+
+    return

--- a/cli/commands/repeat.py
+++ b/cli/commands/repeat.py
@@ -42,6 +42,6 @@ def repeat(mode, verbose=0, quiet=False, _create_request=False):
             click.echo('Repeat set to all tracks.')
     else:
         from cli.commands.status import status
-        status.callback(verbose=verbose, override={'is_repeat': mode in ['all', 'track']})
+        status.callback(verbose=verbose, _override={'is_repeat': mode in ['all', 'track']})
 
     return

--- a/cli/commands/repeat.py
+++ b/cli/commands/repeat.py
@@ -15,18 +15,21 @@ from cli.utils import Spotify
 @click.argument(
     'mode', type=click.Choice(['all', 'track', 'off'], case_sensitive=False)
 )
-def repeat(mode, verbose=0, quiet=False, wait=True):
+def repeat(mode, verbose=0, quiet=False, _create_request=False):
     """Turn repeat on (all/track) or off."""
     state_map = {
         'all': 'context',
         'track': 'track',
         'off': 'off'
     }
-    requests = [{
+    request = {
         'endpoint': 'me/player/repeat?state={}'.format(state_map[mode]),
         'method': 'PUT'
-    }]
-    Spotify.multirequest(requests, wait=wait)
+    }
+    if _create_request:
+        return request
+
+    Spotify.request(**request)
     if quiet:
         return
 

--- a/cli/commands/save.py
+++ b/cli/commands/save.py
@@ -17,7 +17,7 @@ from cli.utils import Spotify
     help='Suppress output.'
 )
 def save(save_type, verbose=0, quiet=False):
-    """Save the current track, album, artist, or playlist to your library."""
+    """Save the current track, album, artist, or playlist."""
     from cli.commands.status import status
     playback_data = status.callback(_return_parsed=True)
     music = playback_data['music']

--- a/cli/commands/save.py
+++ b/cli/commands/save.py
@@ -1,0 +1,59 @@
+import click
+
+from cli.utils import Spotify
+
+
+@click.command(options_metavar='[<options>]')
+@click.option('--track', 'save_type', flag_value='track', default=True)
+@click.option('--album', 'save_type', flag_value='album')
+@click.option('--artist', 'save_type', flag_value='artist')
+@click.option('--playlist', 'save_type', flag_value='playlist')
+@click.option(
+    '-v', '--verbose', count=True,
+    help='Output more info (repeatable flag).'
+)
+@click.option(
+    '-q', '--quiet', is_flag=True,
+    help='Suppress output.'
+)
+def save(save_type, verbose=0, quiet=False):
+    """Save the current track, album, artist, or playlist to your library."""
+    from cli.commands.status import status
+    playback_data = status.callback(_return_parsed=True)
+    music = playback_data['music']
+
+    # parse command and playback context
+    if save_type in ['track', 'album', 'artist']:
+        id_str = music[save_type]['id']
+        name = music[save_type]['name']
+
+    elif save_type == 'playlist':
+        # playlist and radio are both type 'playlist'
+        if music['context']['type'] != 'playlist':
+            click.echo('Error: Current session is not a playlist.', err=True)
+            return
+
+        id_str = music['context']['id']
+        name = Spotify.request('playlists/' + id_str)['name']
+
+
+    # format endpoint
+    data = None
+    headers = {}
+    if save_type in ['track', 'album']:
+        endpoint = 'me/{}s?ids={}'.format(save_type, id_str)
+        message = 'Saved {} - {} to library.'.format(save_type, name)
+
+    elif save_type == 'artist':
+        endpoint = 'me/following?type=artist&ids={}'.format(id_str)
+        message = 'Following {} - {}.'.format(save_type, name)
+
+    elif save_type == 'playlist':
+        endpoint = 'playlists/{}/followers'.format(id_str)
+        message = 'Following {} - {}.'.format(save_type, name)
+        headers = {'Content-Type': 'application/json'}
+        data = {'public': True}
+
+    Spotify.request(endpoint, method='PUT', data=data, headers=headers)
+    click.echo(message)
+    return

--- a/cli/commands/shuffle.py
+++ b/cli/commands/shuffle.py
@@ -1,0 +1,34 @@
+import click
+
+from cli.utils import Spotify
+
+
+@click.command(options_metavar='[<options>]')
+@click.option(
+    '-v', '--verbose', count=True,
+    help='Output more info (repeatable flag).'
+)
+@click.option(
+    '-q', '--quiet', is_flag=True,
+    help='Suppress output.'
+)
+@click.argument(
+    'mode', type=click.Choice(['on', 'off'], case_sensitive=False)
+)
+def shuffle(mode, verbose=0, quiet=False, wait=True):
+    """Turn shuffle on or off."""
+    requests = [{
+        'endpoint': 'me/player/shuffle?state={}'.format('true' if mode == 'on' else 'false'),
+        'method': 'PUT'
+    }]
+    Spotify.multirequest(requests, wait=wait)
+    if quiet:
+        return
+
+    if verbose == 0:
+        click.echo('Shuffle turned {}.'.format(mode))
+    else:
+        from cli.commands.status import status
+        status.callback(verbose=verbose, override={'is_shuffle': mode == 'on'})
+
+    return

--- a/cli/commands/shuffle.py
+++ b/cli/commands/shuffle.py
@@ -32,6 +32,6 @@ def shuffle(mode, verbose=0, quiet=False, _create_request=False):
         click.echo('Shuffle turned {}.'.format(mode))
     else:
         from cli.commands.status import status
-        status.callback(verbose=verbose, override={'is_shuffle': mode == 'on'})
+        status.callback(verbose=verbose, _override={'is_shuffle': mode == 'on'})
 
     return

--- a/cli/commands/shuffle.py
+++ b/cli/commands/shuffle.py
@@ -15,13 +15,16 @@ from cli.utils import Spotify
 @click.argument(
     'mode', type=click.Choice(['on', 'off'], case_sensitive=False)
 )
-def shuffle(mode, verbose=0, quiet=False, wait=True):
+def shuffle(mode, verbose=0, quiet=False, _create_request=False):
     """Turn shuffle on or off."""
-    requests = [{
+    request = {
         'endpoint': 'me/player/shuffle?state={}'.format('true' if mode == 'on' else 'false'),
         'method': 'PUT'
-    }]
-    Spotify.multirequest(requests, wait=wait)
+    }
+    if _create_request:
+        return request
+
+    Spotify.request(**request)
     if quiet:
         return
 

--- a/cli/commands/status.py
+++ b/cli/commands/status.py
@@ -19,7 +19,8 @@ def status(verbose=0, raw=False, override={}):
     res = Spotify.request('me/player', method='GET')
     if raw:
         if verbose >= 0:
-            click.echo(res)
+            import json
+            click.echo(json.dumps(res))
 
         return res
 

--- a/cli/commands/status.py
+++ b/cli/commands/status.py
@@ -34,7 +34,7 @@ def status(verbose=0, raw=False, override={}):
         raise PodcastNotSupported
 
     data['is_shuffle'] = res['shuffle_state']
-    data['is_repeat'] = False if res['repeat_state'] == 'off' else res['repeat_state']
+    data['repeat_state'] = res['repeat_state']
     data['is_playing'] = res['is_playing']
     data['device'] = {
         'name': res['device']['name'],
@@ -72,8 +72,11 @@ def status(verbose=0, raw=False, override={}):
 
     playback_status = 'Playing' if data['is_playing'] else 'Paused'
     playback_options = []
-    if data['is_repeat']:
+    if data['repeat_state'] == 'track':
+        playback_options.append('repeat [track]')
+    elif data['repeat_state'] == 'context':
         playback_options.append('repeat')
+
     if data['is_shuffle']:
         playback_options.append('shuffle')
     playback_str = ''

--- a/cli/commands/status.py
+++ b/cli/commands/status.py
@@ -14,7 +14,7 @@ from cli.utils.functions import format_duration_ms
     '--raw', is_flag=True,
     help='Output raw API response.'
 )
-def status(verbose=0, raw=False, override={}):
+def status(verbose=0, raw=False, _override={}):
     """Describe the current playback session."""
     res = Spotify.request('me/player', method='GET')
     if raw:
@@ -67,8 +67,8 @@ def status(verbose=0, raw=False, override={}):
     music = data['music']
 
     # parsed
-    if override:
-        data.update(override)
+    if _override:
+        data.update(_override)
 
     playback_status = 'Playing' if data['is_playing'] else 'Paused'
     playback_options = []

--- a/cli/spotify.py
+++ b/cli/spotify.py
@@ -10,6 +10,7 @@ from cli.commands.next import _next
 from cli.commands.previous import previous
 from cli.commands.devices import devices
 from cli.commands.volume import volume
+from cli.commands.shuffle import shuffle
 
 
 # CLI group
@@ -31,3 +32,4 @@ cli.add_command(_next)
 cli.add_command(previous)
 cli.add_command(devices)
 cli.add_command(volume)
+cli.add_command(shuffle)

--- a/cli/spotify.py
+++ b/cli/spotify.py
@@ -12,6 +12,7 @@ from cli.commands.devices import devices
 from cli.commands.volume import volume
 from cli.commands.shuffle import shuffle
 from cli.commands.repeat import repeat
+from cli.commands.save import save
 
 
 # CLI group
@@ -35,3 +36,4 @@ cli.add_command(devices)
 cli.add_command(volume)
 cli.add_command(shuffle)
 cli.add_command(repeat)
+cli.add_command(save)

--- a/cli/spotify.py
+++ b/cli/spotify.py
@@ -11,6 +11,7 @@ from cli.commands.previous import previous
 from cli.commands.devices import devices
 from cli.commands.volume import volume
 from cli.commands.shuffle import shuffle
+from cli.commands.repeat import repeat
 
 
 # CLI group
@@ -33,3 +34,4 @@ cli.add_command(previous)
 cli.add_command(devices)
 cli.add_command(volume)
 cli.add_command(shuffle)
+cli.add_command(repeat)

--- a/cli/utils/Spotify.py
+++ b/cli/utils/Spotify.py
@@ -91,7 +91,11 @@ def _handle_request(endpoint, method='GET', data=None, headers={}, ignore_errs=[
                 if type(res_str) == bytes:
                     res_str = res_str.decode('utf-8')
 
-                return json.loads(res_str)
+                if len(res_str) == 0:
+                    return {}
+                else:
+                    return json.loads(res_str)
+
             elif res.status == 204:
                 return {}
 

--- a/cli/utils/Spotify.py
+++ b/cli/utils/Spotify.py
@@ -7,15 +7,19 @@ from cli.utils.constants import *
 from cli.utils.exceptions import *
 
 
+def _read_json(file_path):
+    if not os.path.exists(file_path):
+        return {}
+    with open(file_path) as f:
+        data = json.load(f)
+    return data
+
 def get_credentials():
     """Read locally stored credentials file for API authorization."""
-    if not os.path.exists(CREDS_PATH):
-        return {}
+    return _read_json(CREDS_PATH)
 
-    with open(CREDS_PATH) as f:
-        creds = json.load(f)
-
-    return creds
+def get_config():
+    return _read_json(CONFIG_PATH)
 
 
 def refresh(auth_code=None):

--- a/cli/utils/Spotify.py
+++ b/cli/utils/Spotify.py
@@ -21,6 +21,13 @@ def get_credentials():
 def get_config():
     return _read_json(CONFIG_PATH)
 
+def update_config(update_dict):
+    config = get_config()
+    config.update(update_dict)
+    with open(CONFIG_PATH, 'w+') as f:
+        json.dump(config, f)
+    return
+
 
 def refresh(auth_code=None):
     """Refresh Spotify access token.

--- a/cli/utils/constants.py
+++ b/cli/utils/constants.py
@@ -1,5 +1,4 @@
 import os
-import urllib.parse as ul
 
 # spotify API URL
 API_URL = 'https://api.spotify.com/v1/'
@@ -12,6 +11,7 @@ HOME = os.path.expanduser('~')
 CONFIG_DIR = os.path.join(HOME, '.config')
 CREDS_DIR = os.path.join(CONFIG_DIR, 'spotify-cli')
 CREDS_PATH = os.path.join(CREDS_DIR, 'credentials.json')
+CONFIG_PATH = os.path.join(CREDS_DIR, 'config.json')
 for folder in [CONFIG_DIR, CREDS_DIR]:
     if not os.path.exists(folder):
         os.mkdir(folder)
@@ -20,16 +20,48 @@ for folder in [CONFIG_DIR, CREDS_DIR]:
 REFRESH_URI = 'https://asia-east2-spotify-cli-283006.cloudfunctions.net/auth-refresh'
 REDIRECT_URI = 'https://asia-east2-spotify-cli-283006.cloudfunctions.net/auth-redirect'
 CLIENT_ID = '3e96f0ef8d6d4e0994e15bf2b168235f'
-AUTH_SCOPES = [
-   'user-read-playback-state',
-   'user-modify-playback-state',
-   'user-library-modify',
-   'user-top-read',
-   'user-library-read',
-   'user-read-recently-played',
-]
-AUTH_URL = (
-    'https://accounts.spotify.com/authorize?client_id={}'
-    '&response_type=code&redirect_uri={}&scope={}'
-    .format(CLIENT_ID, ul.quote_plus(REDIRECT_URI), ul.quote_plus(" ".join(AUTH_SCOPES)))
-)
+
+AUTH_SCOPES_MAPPING = [
+    {
+        'value': 'default',
+        'name': 'Read & modify playback.',
+        'scopes': [
+           'user-read-playback-state',
+           'user-modify-playback-state',
+           'user-read-recently-played',
+        ],
+    },
+    {
+        'value': 'playlists-read', 
+        'name': 'Read user playlists.',
+        'scopes': [
+            'playlist-read-collaborative',
+            'playlist-read-private',
+        ],
+    },
+    {
+        'value': 'playlists-modify', 
+        'name': 'Modify user playlists.',
+        'scopes': [
+            'playlist-modify-public',
+            'playlist-modify-private',
+        ],
+    },
+    {
+        'value': 'user-read',
+        'name': 'Read user library, followed artists/users, and top artists/tracks.',
+        'scopes': [
+            'user-top-read',
+            'user-library-read',
+            'user-follow-read',
+        ],
+    },
+    {
+        'value': 'user-modify',
+        'name': 'Modify user library and followed artists/users.',
+        'scopes': [
+            'user-library-modify',
+            'user-follow-modify',
+        ],
+    }
+] 

--- a/cli/utils/functions.py
+++ b/cli/utils/functions.py
@@ -1,4 +1,10 @@
+import urllib.parse as ul
+from uuid import uuid1
 from datetime import timedelta
+
+from cli.utils.constants import *
+
+
 def format_duration_ms(ms):
     def _format(d):
         d = str(d)
@@ -12,3 +18,23 @@ def format_duration_ms(ms):
 
     m, s = divmod(s, 60)
     return '{}:{}'.format(_format(m), _format(s))
+
+
+def build_auth_url(additional_scopes=[]):
+    user_scopes = ['default'] + additional_scopes
+    scopes = []
+    for scope in AUTH_SCOPES_MAPPING:
+        if scope['value'] in user_scopes:
+            scopes += scope['scopes']
+
+    auth_url = (
+        'https://accounts.spotify.com/authorize?client_id={}'
+        '&response_type=code&redirect_uri={}&scope={}&state={}'
+        .format(
+            CLIENT_ID,
+            ul.quote_plus(REDIRECT_URI),
+            ul.quote_plus(" ".join(scopes)),
+            uuid1()
+        )
+    )
+    return auth_url


### PR DESCRIPTION
- --raw flag outputs usable JSON (double quotes); + readme documentation
- updated auth handling to allow selecting additional scopes
- spotify.auth.login scope auth saves previous settings; confirmation prompt
- added nested pycache to gitignore
- added ignore_errs param to Spotify.request; added Spotify.multirequest for multithreading
- added shuffle command
- added repeat command; edited status repeat state
- added repeat & shuffle options for play command
- renamed override command to _override (internal)
- added ids to parsed status command body
- error handling for empty responses
- removed unneeded import from pause
- status parsing improvements
- added spotify.save command to save current track/album/artist/playlist to library
- updated docs
- ignore txt
