### PR TITLE
Fix default scopes handling

### DIFF
--- a/cli/utils/functions.py
+++ b/cli/utils/functions.py
@@ -24,7 +24,7 @@ def format_duration_ms(ms):
 
 def build_auth_url(additional_scopes=[]):
     """Create the OAuth URL for the user-approved scopes."""
-    user_scopes = ['default'] + additional_scopes
+    user_scopes = ['Read & modify playback.'] + additional_scopes
     scopes = []
     for scope in AUTH_SCOPES_MAPPING:
         if scope['name'] in user_scopes:


### PR DESCRIPTION
The `build_auth_url` function was looking for scope "names" (that is, the descriptions showed in the user interface, defined in `AUTH_SCOPES_MAPPING`) but used `default` that is the value (and not the name) for the default scopes in the same constants.

An easy fix would be change `functions.py:27` in `user_scopes = ['Read & modify playback.'] + additional_scopes`, but is better to use coded value rather than description, so I made the changes shown in this PR.

Unfortunately, there is a drawback: it seems that using both `value` and `checked` in a `choice` from `PyInquirer` is not working as expected, resulting in choices not preselected even if they have the property `'checked': True`.

But I don't know Python nor PyInquirer so maybe I'm missing something.