### PR TITLE
Add a "toggle" subcommand toggling reproduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Commands:
   search    Search for any Spotify content.
   shuffle   Turn shuffle on or off.
   status    Describe the current playback session.
+  toggle    Resume any paused playback, or pause it if already running.
   top       List your top tracks or artists.
   volume    Control the active device's volume level (0-100).
 ```

--- a/cli/commands/toggle.py
+++ b/cli/commands/toggle.py
@@ -1,0 +1,43 @@
+import click
+
+from ..utils import Spotify
+from ..utils.exceptions import NoPlaybackError
+
+
+@click.command(options_metavar='[<options>]')
+@click.option(
+    '-v', '--verbose', count=True,
+    help='Output more info (repeatable flag).'
+)
+@click.option(
+    '-q', '--quiet', is_flag=True,
+    help='Suppress output.'
+)
+def toggle(verbose=0, quiet=False, raw=False):
+    """Resume any paused playback, or pause it if already running."""
+
+    res = Spotify.request('me/player', method='GET')
+    if not res:
+        raise NoPlaybackError
+
+    if res['is_playing']:
+        Spotify.request(
+            'me/player/pause', method='PUT',
+            ignore_errs=[403],
+            handle_errs={404: NoPlaybackError}
+        )
+        if not quiet:
+            from cli.commands.status import status
+            status.callback(verbose=verbose, _override={'is_playing': False})
+    else:
+        Spotify.request(
+            'me/player/play', method='PUT',
+            ignore_errs=[403],
+            handle_errs={404: NoPlaybackError}
+        )
+
+        if not quiet:
+            from cli.commands.status import status
+            status.callback(verbose=verbose, _override={'is_playing': True})
+
+    return

--- a/cli/spotify.py
+++ b/cli/spotify.py
@@ -16,6 +16,7 @@ from cli.commands.save import save
 from cli.commands.queue import queue
 from cli.commands.browse import browse
 from cli.commands.history import history
+from cli.commands.toggle import toggle
 from cli.commands.top import top
 from cli.commands.search import search
 
@@ -46,5 +47,6 @@ cli.add_command(save)
 cli.add_command(queue)
 cli.add_command(browse)
 cli.add_command(history)
+cli.add_command(toggle)
 cli.add_command(top)
 cli.add_command(search)


### PR DESCRIPTION
With this patch, a new subcommand "toggle" is added. It pauses any
running reproduction, or resumes it if Spotify was active but not playing.

This command is useful for binding to "play/pause" media buttons on
keyboards or compatible headphones.