### PR TITLE
Add 3.10 support by fixing PyInquirer dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# VS Code project settings
+.vscode/
+*.code-workspace

--- a/.gitignore
+++ b/.gitignore
@@ -111,7 +111,7 @@ celerybeat.pid
 
 # Environments
 .env
-.venv
+.*venv
 env/
 venv/
 ENV/

--- a/cli/commands/auth.py
+++ b/cli/commands/auth.py
@@ -77,7 +77,8 @@ def login(client_id='', client_secret=''):
         'By default, spotify-cli will enable reading & '
         'modifying the playback state.\n'
     )
-    choice = prompt([{
+    # UPDATED: Now using the GitHub repo instead of PyPI
+    choice = prompt.prompt([{
         'type': 'checkbox',
         'name': 'scopes',
         'message': (
@@ -98,7 +99,7 @@ def login(client_id='', client_secret=''):
     click.confirm('Proceed with these settings?', default=True, abort=True)
 
     # handle auth and save credentials
-    url = build_auth_url(additional_scopes, client_id)
+    url = build_auth_url(additional_scopes, client_id)  # type: ignore
     webbrowser.open(url)
     click.echo(
         '\nGo to the following link in your browser:\n\n\t{}\n'
@@ -120,7 +121,7 @@ def login(client_id='', client_secret=''):
 def status(verbose):
     """Show who's logged in."""
     user_data = Spotify.request('me', method='GET')
-    click.echo('Logged in as {}'.format(user_data['display_name']))
+    click.echo('Logged in as {}'.format(user_data['display_name']))  # type: ignore
     if verbose:
         click.echo('Credentials stored in {}'.format(CREDS_PATH))
     return

--- a/cli/commands/devices.py
+++ b/cli/commands/devices.py
@@ -24,7 +24,7 @@ def devices(verbose=False, switch_to='', raw=False):
     Only devices with an active Spotify session will be recognized.
     """
     res = Spotify.request('me/player/devices', method='GET')
-    if not res.get('devices'):
+    if not res.get('devices'):  # type: ignore
         raise NoPlaybackError
 
     if raw:
@@ -36,7 +36,7 @@ def devices(verbose=False, switch_to='', raw=False):
 
     # parsed
     devices_list = sorted(
-        res['devices'],
+        res['devices'],  # type: ignore
         key=lambda x: (x['is_active'], x['type'], x['name'])
     )
     for device in devices_list:
@@ -108,7 +108,8 @@ def devices(verbose=False, switch_to='', raw=False):
             'message': message,
             'choices': choices,
         }]
-        choice = prompt(questions)
+        # UPDATED: Now using the GitHub repo instead of PyPI
+        choice = prompt.prompt(questions)
         if not choice:
             return
 

--- a/cli/spotify.py
+++ b/cli/spotify.py
@@ -32,7 +32,10 @@ from cli.utils.classes import AliasedGroup
     options_metavar='[<options>]',
     subcommand_metavar='<command>'
 )
-@click.version_option(message='spotify-cli, version %(version)s')
+# UPDATED: Add package name to stop click RuntimeError caused by not
+# detecting the package_name
+@click.version_option(message='spotify-cli, version %(version)s',
+                      package_name='spotify-cli')
 def cli():
     pass
 

--- a/cli/spotify.py
+++ b/cli/spotify.py
@@ -1,25 +1,29 @@
+"""spotify.py
+
+CLI entry point.
+"""
+
 import click
 
-from cli.utils.classes import AliasedGroup
-
 from cli.commands.auth import auth
-from cli.commands.status import status
-from cli.commands.play import play
-from cli.commands.pause import pause
-from cli.commands.next import _next
-from cli.commands.previous import previous
+from cli.commands.browse import browse
 from cli.commands.devices import devices
-from cli.commands.volume import volume
-from cli.commands.shuffle import shuffle
+from cli.commands.history import history
+from cli.commands.next import _next
+from cli.commands.pause import pause
+from cli.commands.play import play
+from cli.commands.previous import previous
+from cli.commands.queue import queue
 from cli.commands.repeat import repeat
 from cli.commands.save import save
-from cli.commands.queue import queue
-from cli.commands.browse import browse
-from cli.commands.history import history
-from cli.commands.toggle import toggle
-from cli.commands.top import top
 from cli.commands.search import search
 from cli.commands.seek import seek
+from cli.commands.shuffle import shuffle
+from cli.commands.status import status
+from cli.commands.toggle import toggle
+from cli.commands.top import top
+from cli.commands.volume import volume
+from cli.utils.classes import AliasedGroup
 
 
 # CLI group
@@ -33,22 +37,27 @@ def cli():
     pass
 
 
-# commands
-cli.add_command(auth)
-cli.add_command(status)
-cli.add_command(play)
-cli.add_command(pause)
-cli.add_command(_next)
-cli.add_command(previous)
-cli.add_command(devices)
-cli.add_command(volume)
-cli.add_command(shuffle)
-cli.add_command(repeat)
-cli.add_command(save)
-cli.add_command(queue)
-cli.add_command(browse)
-cli.add_command(history)
-cli.add_command(toggle)
-cli.add_command(top)
-cli.add_command(search)
-cli.add_command(seek)
+# Commands
+cli.add_command(auth)  # type: ignore
+cli.add_command(status)  # type: ignore
+cli.add_command(play)  # type: ignore
+cli.add_command(pause)  # type: ignore
+cli.add_command(_next)  # type: ignore
+cli.add_command(previous)  # type: ignore
+cli.add_command(devices)  # type: ignore
+cli.add_command(volume)  # type: ignore
+cli.add_command(shuffle)  # type: ignore
+cli.add_command(repeat)  # type: ignore
+cli.add_command(save)  # type: ignore
+cli.add_command(queue)  # type: ignore
+cli.add_command(browse)  # type: ignore
+cli.add_command(history)  # type: ignore
+cli.add_command(toggle)  # type: ignore
+cli.add_command(top)  # type: ignore
+cli.add_command(search)  # type: ignore
+cli.add_command(seek)  # type: ignore
+
+
+# For debugging purposes: python -m cli.spotify
+if __name__ == "__main__":
+    cli()

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 import os
 from setuptools import setup, find_packages
 
+# PS> $env:RELEASE_VERSION = "vX.Y.Z"
+# pip install .
 VERSION = os.environ['RELEASE_VERSION']
 
 with open('README.md', 'r') as f:
@@ -22,7 +24,8 @@ setup(
     packages=find_packages(),
     install_requires=[
         'Click',
-        'PyInquirer',
+        # PyPI release does not support Python v3.10 (causes ImportError)
+        'PyInquirer @ git+https://github.com/CITGuru/PyInquirer',
         'tabulate',
     ],
     entry_points='''

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,6 @@
 import os
 from setuptools import setup, find_packages
 
-# PS> $env:RELEASE_VERSION = "vX.Y.Z"
-# pip install .
 VERSION = os.environ['RELEASE_VERSION']
 
 with open('README.md', 'r') as f:


### PR DESCRIPTION
Users with Python 3.10+ installed face issue #23 caused by the PyInquirer dependency. However, I noticed that this issue is only present in the PyPI release. The [official GitHub repository](https://github.com/CITGuru/PyInquirer), although [not updated for a while](https://github.com/CITGuru/PyInquirer/issues/159), is ahead of this release and supports 3.10, so I simply changed the dependency in setup.py to pull from this repo instead of from PyPI. Expectedly, this affects the files:

- setup.py
- cli/commands/auth.py
- cli/commands/devices.py

I also made a change to cli/spotify.py since the `--version` flag implemented by `click.version_info` would fail to detect the package name. I don't know if this issue is unique to my development environment, but I updated the decorator just in case. Users still see the same output, `spotify-cli, version X.Y.Z`.