### PR TITLE
Refactor to use 'inquirer' instead of 'PyInquirer'.

### DIFF
--- a/cli/commands/auth.py
+++ b/cli/commands/auth.py
@@ -62,7 +62,7 @@ def login(client_id='', client_secret=''):
 
     # select scopes
     import webbrowser
-    from PyInquirer import prompt
+    from inquirer import prompt, Checkbox
     enabled_scopes = Spotify.get_config().get('auth_scopes', [])
     choices = []
     for scope in AUTH_SCOPES_MAPPING:
@@ -77,15 +77,15 @@ def login(client_id='', client_secret=''):
         'By default, spotify-cli will enable reading & '
         'modifying the playback state.\n'
     )
-    choice = prompt([{
-        'type': 'checkbox',
-        'name': 'scopes',
-        'message': (
-            'Please select which additional features '
-            'you want to authorize.'
-        ),
-        'choices': choices,
-    }])
+
+    questions = [
+        Checkbox(
+            'scopes',
+            message="Please select which additional features you want to authorize.",
+            choices=choices
+        )
+    ]
+    choice = prompt(questions)
     if not choice:
         return
 

--- a/cli/commands/devices.py
+++ b/cli/commands/devices.py
@@ -101,13 +101,14 @@ def devices(verbose=False, switch_to='', raw=False):
         )
 
         # interactive prompt
-        from PyInquirer import prompt
-        questions = [{
-            'type': 'list',
-            'name': 'formatted_name',
-            'message': message,
-            'choices': choices,
-        }]
+        from inquirer import prompt, List
+        questions = [
+            List(
+                'formatted_name',
+                message=message,
+                choices=choices
+            )
+        ]
         choice = prompt(questions)
         if not choice:
             return

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'Click',
-        'PyInquirer',
+        'inquirer',
         'tabulate',
     ],
     entry_points='''


### PR DESCRIPTION
This PR removes the use of PyInquirer which appears to be dead. It should fix [this bug](https://github.com/ledesmablt/spotify-cli/issues/23) and allow the use of more modern python versions.